### PR TITLE
Changing paths to be compatible with Plugin Framework 0.5.3

### DIFF
--- a/web/installation/install.setup.xml
+++ b/web/installation/install.setup.xml
@@ -1,11 +1,11 @@
 <!DOCTYPE sailpoint PUBLIC "sailpoint.dtd" "sailpoint.dtd">
 <sailpoint>
-    <ImportAction name='include' value='{plugin_root}Configuration.xml'/>
-    <ImportAction name='include' value='{plugin_root}QuickLinkOptions.xml'/>
-    <ImportAction name='include' value='{plugin_root}QuickLink.xml'/>
-    <ImportAction name='include' value='{plugin_root}Permissions.xml'/>
-    <ImportAction name='include' value='{plugin_root}ServiceDefinition.xml'/>
-  <ImportAction name='include' value='{plugin_root}Policy.xml'/>
-  <ImportAction name='include' value='{plugin_root}TaskDefinition.xml'/>
-  <ImportAction name='include' value='{plugin_root}Widget.xml'/>
+    <ImportAction name='include' value='{plugin_root}/installation/Configuration.xml'/>
+    <ImportAction name='include' value='{plugin_root}/installation/QuickLinkOptions.xml'/>
+    <ImportAction name='include' value='{plugin_root}/installation/QuickLink.xml'/>
+    <ImportAction name='include' value='{plugin_root}/installation/Permissions.xml'/>
+    <ImportAction name='include' value='{plugin_root}/installation/ServiceDefinition.xml'/>
+  <ImportAction name='include' value='{plugin_root}/installation/Policy.xml'/>
+  <ImportAction name='include' value='{plugin_root}/installation/TaskDefinition.xml'/>
+  <ImportAction name='include' value='{plugin_root}/installation/Widget.xml'/>
 </sailpoint>

--- a/web/installation/upgrade.setup.xml
+++ b/web/installation/upgrade.setup.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE sailpoint PUBLIC "sailpoint.dtd" "sailpoint.dtd">
 <sailpoint>
-  <ImportAction name='include' value='{plugin_root}Permissions.xml'/>
-  <ImportAction name='include' value='{plugin_root}ServiceDefinition.xml'/>
+  <ImportAction name='include' value='{plugin_root}/installation/Permissions.xml'/>
+  <ImportAction name='include' value='{plugin_root}/installation/ServiceDefinition.xml'/>
 </sailpoint>


### PR DESCRIPTION
Tried to install HelloWorld plugin after installing recent Plugin Framework 0.5.3. Installation failed because it could not find several files. I ended up changing paths to include '/installation/' after the {plugin_root} variable. 
